### PR TITLE
Add support for 3 Finnish websites

### DIFF
--- a/lib/domain/selectors.ts
+++ b/lib/domain/selectors.ts
@@ -15,6 +15,7 @@ export const supportedDomains = [
     'inspiredtaste.net',
     'justonecookbook.com',
     'kingarthurbaking.com',
+    'kotikokki.net',
     'littlesweetbaker.com',
     'loveandlemons.com',
     'natashaskitchen.com',
@@ -28,9 +29,8 @@ export const supportedDomains = [
     'tasty.co',
     'thepioneerwoman.com',
     'thestayathomechef.com',
-    'whatsgabycooking.com',
     'valio.fi',
-    'kotikokki.net',
+    'whatsgabycooking.com',
     'yhteishyva.fi'
 ] as const;
 
@@ -129,6 +129,12 @@ export const recipeSelectors: domainInformationSelector = {
         ingredientsSelector: 'div[class="ingredient-section"] > ul > li',
         directionsSelector: 'article[class="recipe__instructions"] > div > ol > li > p'
     },
+    'kotikokki.net' : {
+        titleSelector: 'h1[id="recipe-title"]',
+        ingredientsSelector: 'tr.ingredient > td.name',
+        ingredientsAmountSelector: 'tr.ingredient > td.amount-unit',
+        directionsSelector: 'div.instructions > span > p'
+    },
     'littlesweetbaker.com' : {
         titleSelector: 'h2[class="tasty-recipes-title"]',
         ingredientsSelector: 'div[class="tasty-recipes-ingredients"] > div > ul > li',
@@ -195,22 +201,16 @@ export const recipeSelectors: domainInformationSelector = {
         ingredientsSelector: 'ul[class="wprm-recipe-ingredients"] > li',
         directionsSelector: 'ul[class="wprm-recipe-instructions"] > li',
     },
-    'whatsgabycooking.com' : {
-        titleSelector: 'h1[class="entry-title"]',
-        ingredientsSelector: 'li[class="wprm-recipe-ingredient"]',
-        directionsSelector: 'div[class="wprm-recipe-instruction-text"]',
-    },
     'valio.fi' : {
         titleSelector: 'h1[class^="Title"]',
         ingredientsSelector: 'td[class^="IngredientRowRight"]',
         ingredientsAmountSelector: 'td[class^="IngredientRowLeft"]',
         directionsSelector: 'div[class^="InstructionsRowRight"]'
     },
-    'kotikokki.net' : {
-        titleSelector: 'h1[id="recipe-title"]',
-        ingredientsSelector: 'tr.ingredient > td.name',
-        ingredientsAmountSelector: 'tr.ingredient > td.amount-unit',
-        directionsSelector: 'div.instructions > span > p'
+    'whatsgabycooking.com' : {
+        titleSelector: 'h1[class="entry-title"]',
+        ingredientsSelector: 'li[class="wprm-recipe-ingredient"]',
+        directionsSelector: 'div[class="wprm-recipe-instruction-text"]',
     },
     'yhteishyva.fi' : {
         titleSelector: 'h1[class~="title"]',

--- a/lib/domain/selectors.ts
+++ b/lib/domain/selectors.ts
@@ -29,6 +29,9 @@ export const supportedDomains = [
     'thepioneerwoman.com',
     'thestayathomechef.com',
     'whatsgabycooking.com',
+    'valio.fi',
+    'kotikokki.net',
+    'yhteishyva.fi'
 ] as const;
 
 export const domainIsSupported = (domain: string): boolean => {
@@ -197,6 +200,24 @@ export const recipeSelectors: domainInformationSelector = {
         ingredientsSelector: 'li[class="wprm-recipe-ingredient"]',
         directionsSelector: 'div[class="wprm-recipe-instruction-text"]',
     },
+    'valio.fi' : {
+        titleSelector: 'h1[class^="Title"]',
+        ingredientsSelector: 'td[class^="IngredientRowRight"]',
+        ingredientsAmountSelector: 'td[class^="IngredientRowLeft"]',
+        directionsSelector: 'div[class^="InstructionsRowRight"]'
+    },
+    'kotikokki.net' : {
+        titleSelector: 'h1[id="recipe-title"]',
+        ingredientsSelector: 'tr.ingredient > td.name',
+        ingredientsAmountSelector: 'tr.ingredient > td.amount-unit',
+        directionsSelector: 'div.instructions > span > p'
+    },
+    'yhteishyva.fi' : {
+        titleSelector: 'h1[class~="title"]',
+        ingredientsSelector: 'div.recipe__ingredients div.ingredient-row > div[class~="name"]',
+        ingredientsAmountSelector: 'div.recipe__ingredients div.ingredient-row > div[class~="amount"]',
+        directionsSelector: 'div.recipe__step-ingredients > div > p'
+    }
 }
 
 // Wishlist


### PR DESCRIPTION
Add support for Finnish cooking sites valio.fi, kotikokki.net and yhteishyva.fi

Sample urls:
- https://www.valio.fi/reseptit/suklaa-cookies/
- https://www.kotikokki.net/kumppanit/alfez/reseptit/nayta/866334/Harissalla%20marinoidut%20kanavartaat/
- https://yhteishyva.fi/reseptit/veriappelsiinipiiras/2tWwcxDpTfg8m1HBDMCXe9