### PR TITLE
Change HTML heading tags to be more semantic

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -28,21 +28,17 @@ export default function Layout({
       <header className={styles.header}>
         {home ? (
           <>
-            <h1 className={utilStyles.heading5Xl}>🌯</h1>
+            <span className={utilStyles.heading5Xl}>🌯</span>
             <h1 className={utilStyles.heading2Xl}>{name}</h1>
           </>
         ) : (
           <>
             <Link href="/">
-              <a>
-                <h1 className={utilStyles.heading5Xl}>🌯</h1>
-              </a>
+              <a className={utilStyles.heading5Xl}>🌯</a>
             </Link>
-            <h2 className={utilStyles.headingLg}>
-              <Link href="/">
-                <a className={utilStyles.colorInherit}>{name}</a>
-              </Link>
-            </h2>
+            <Link href="/">
+              <a className={utilStyles.colorInherit + " " + utilStyles.headingLg}>{name}</a>
+            </Link>
           </>
         )}
       </header>

--- a/pages/recipes.tsx
+++ b/pages/recipes.tsx
@@ -72,7 +72,7 @@ export default function Recipe() {
             <div>
                 <h1>{title}</h1>
                 <a href={originalURL} target="_blank">Original Recipe</a>
-                <h1>Ingredients</h1>
+                <h2>Ingredients</h2>
                 { ingredients.map((section, idx) => 
                     (
                         <>
@@ -81,7 +81,7 @@ export default function Recipe() {
                         </>
                     )
                 )}
-                <h1>Directions</h1>
+                <h2>Directions</h2>
                 { directions.map((direction, idx) => <p key={`${direction}-${idx}`}>{direction}</p>) }
             </div>
         </Layout>

--- a/styles/utils.module.css
+++ b/styles/utils.module.css
@@ -25,6 +25,7 @@
 .headingLg {
   font-size: 1.5rem;
   line-height: 1.4;
+  font-weight: 800;
   margin: 1rem 0;
 }
 


### PR DESCRIPTION
This will make the site easier to use with screen readers and other assistive technologies. For example, a site shouldn't have multiple H1 tags, and the site shouldn't "skip" any levels, like going from H1 to H3.